### PR TITLE
Add no default feature flag panic-multiple-global-spawners

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The API is capable to spawn, join and cancel tasks as what `tokio`, `smol` and `
 
 ## Packages
 1. [spawns-core][] provides `Spawn` and `enter()` for async runtimes to setup thread context task spawner.
-2. [spawns-compat][] provides compatibility for `tokio`, `smol` and `async-global-executor`(which is used by `async-std`) through feature gates. Be ware of that, `smol` and `async-global-executor` can't coexist as they don't have `tokio::runtime::Handle::try_current()` like method to detect thread context aware executor. `spawn()` will panic if can't find any thread context spawners but multiple blinding global spawners.
+2. [spawns-compat][] provides compatibility for `tokio`, `smol` and `async-global-executor`(which is used by `async-std`) through feature gates.
 3. [spawns-executor][] provides full functional `block_on` with both current thread executor and multi-thread executor.
 4. [spawns][] exports all above packages including feature gates `tokio`, `smol` and `async-global-executor`. In addition, it provides feature gate `executor` to include `spawns-executor`.
 

--- a/spawns-compat/src/lib.rs
+++ b/spawns-compat/src/lib.rs
@@ -22,13 +22,3 @@ mod tokio;
 
 #[cfg(feature = "async-global-executor")]
 mod async_global_executor;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    #[cfg(all(feature = "async-global-executor", feature = "smol"))]
-    #[should_panic(expected = "multiple global spawners")]
-    fn multiple_global() {
-        spawns_core::spawn(async move {});
-    }
-}

--- a/spawns-core/Cargo.toml
+++ b/spawns-core/Cargo.toml
@@ -12,6 +12,7 @@ description = "Async runtime agnostic thread context task spawner for Rust"
 [features]
 default = []
 compat = ["linkme"]
+panic-multiple-global-spawners = []
 test-compat-global1 = ["compat"]
 test-compat-global2 = ["compat", "test-compat-global1"]
 

--- a/spawns-core/src/compat.rs
+++ b/spawns-core/src/compat.rs
@@ -38,11 +38,11 @@ pub(crate) fn find_spawn() -> Option<fn(Task)> {
     }) {
         Some(spawn) => Some(spawn),
         None => {
+            #[cfg(feature = "panic-multiple-global-spawners")]
             if globals > 1 {
                 panic!("multiple global spawners")
-            } else {
-                last_global.copied()
             }
+            last_global.copied()
         }
     }
 }

--- a/spawns-core/src/spawn.rs
+++ b/spawns-core/src/spawn.rs
@@ -255,10 +255,18 @@ mod tests {
         }
 
         #[cfg(feature = "test-compat-global2")]
+        #[cfg(feature = "panic-multiple-global-spawners")]
         #[test]
         #[should_panic(expected = "multiple global spawners")]
         fn multiple_globals() {
             spawn(ready(()));
+        }
+
+        #[cfg(feature = "test-compat-global2")]
+        #[cfg(not(feature = "panic-multiple-global-spawners"))]
+        #[test]
+        fn multiple_globals() {
+            block_on(spawn(ready(()))).unwrap();
         }
     }
 }

--- a/spawns/Cargo.toml
+++ b/spawns/Cargo.toml
@@ -15,6 +15,7 @@ executor = ["spawns-executor"]
 tokio = ["spawns-compat/tokio"]
 smol = ["spawns-compat/smol"]
 async-global-executor = ["spawns-compat/async-global-executor"]
+panic-multiple-global-spawners = ["spawns-core/panic-multiple-global-spawners"]
 
 [dependencies]
 spawns-core = { path = "../spawns-core", version = "1.0.2" }

--- a/spawns/src/lib.rs
+++ b/spawns/src/lib.rs
@@ -41,8 +41,8 @@
 //! * `smol`: uses `smol::spawn` to spawn task in absent of thread local spawners.
 //! * `async-global-executor`: uses `async_global_executor::spawn` to spawn task in absent of thread local spawners.
 //!
-//! Be aware that, `smol` and `async-global-executor` are not compatible as they both blindly spawn
-//! tasks. [spawn()] will panic if there is no thread local spawners but multiple global spawners.
+//! Since `smol` and `async-global-executor` both blindly spawn tasks, it is unknown which one is
+//! chosen. Feature "panic-multiple-global-spawners" is provided to panic on this situation.
 
 pub use spawns_core::*;
 


### PR DESCRIPTION
Global executors should be capable to spawn everywhere and work with all
runtime agnostic io, net, timer, channel and etc. crates. So there is no
reason to panic on default if there are multiple global spawners. But
still a feature flag for binary crate to decide.

Currently, spawns choose an random on from `linkme`. We could introduce
named global spawner to choose from env variable.
